### PR TITLE
The BIND methods should return t to indicate success

### DIFF
--- a/trivial-ldap.lisp
+++ b/trivial-ldap.lisp
@@ -14,7 +14,7 @@
 
 (in-package :trivial-ldap)
 
-(declaim (optimize (speed 0) (safety 3) (debug 3) (compilation-speed 0)))
+(declaim (optimize (speed 3) (safety 1) (debug 1) (compilation-speed 0)))
 
 (defparameter *init-sec-fn* nil)
 (defparameter *wrap-fn* nil)


### PR DESCRIPTION
The function POSSIBLY-REOPEN-AND-BIND throws an error if the underlying BIND method returns NIL. As it happens, the SASL/GSS functions did not take this into considering and thus caused the bind operation to fail if the function happened to return NIL.

This fix ensures that the bind functions always returns T. If an error occurs, they will raise an error.
