### PR TITLE
Fix for unexpected ldap-search attribute selection

### DIFF
--- a/trivial-ldap.lisp
+++ b/trivial-ldap.lisp
@@ -1,5 +1,5 @@
-;;;; trivial-ldap.lisp -- a one file, all lisp client implementation of
-;;;; parts of RFC 2261.
+;;;; TRIVIAL-LDAP -- a one file, all lisp client implementation of
+;;;; parts of RFC 2261.  
 
 ;;;; Please see the trivial-ldap.html file for documentation and limitations.
 
@@ -57,7 +57,7 @@
 	   :reader filter
 	   :initform "Not Supplied"))
   (:report (lambda (c stream)
-	     (format stream "Filter Error: ~A~%Supplied Filter: ~A~%"
+	     (format stream "Filter Error: ~A~%Supplied Filter: ~A~%" 
 		     (mesg c) (filter c)))))
 
 (define-condition ldap-connection-error (ldap-error)
@@ -119,7 +119,7 @@
 (defun base10->base256 (int)
   "Return representation of an integer as a list of base 256 'digits'."
   (assert (and (integerp int) (>= int 0)))
-  (or
+  (or 
    (do ((i 0 (+ i 8))
 	(j int (ash j -8))
 	(result nil (cons (logand #xFF j) result)))
@@ -230,13 +230,13 @@
 
 (defun string->char-code-list (string)
   "Convert a string into a list of bytes."
-   (let ((string (etypecase string
+   (let ((string (etypecase string 
  		  (string string)
  		  (symbol (symbol-name string)))))
      #-(or allegro ccl sbcl lispworks)
      (map 'list #'char-code string)
      #+ccl
-     (coerce
+     (coerce 
       (ccl::encode-string-to-octets string :external-format :utf-8) 'list)
      #+sbcl
      (coerce (sb-ext:string-to-octets string :external-format :utf-8) 'list)
@@ -306,20 +306,20 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-constant +max-int+ (- (expt 2 31) 1)
     "As defined by the LDAP RFC.")
-
+  
   (define-constant +ber-class-id+
       '((universal   . #b00000000) (application . #b01000000)
 	(context     . #b10000000) (private     . #b11000000)))
-
+  
   (define-constant +ber-p/c-bit+
       '((primitive   . #b00000000) (constructed . #b00100000)))
-
+  
   (define-constant +ber-multibyte-tag-number+ #b00011111
     "Flag indicating tag number requires > 1 byte")
-
+  
   (define-constant +ber-long-length-marker+   #b10000000
     "Flag indicating more tag number bytes follow")
-
+  
   (defun ber-class-id (class)
     "Return the bits to construct a BER tag of type class."
     (or (cdr (assoc class +ber-class-id+))
@@ -340,10 +340,10 @@ CLASS should be the symbol universal, applicaiton, context, or private.
 P/C should be the symbol primitive or constructed.
 NUMBER should be either an integer or LDAP application name as symbol."
     (let ((byte (ber-tag-type class p/c))
-	  (number (etypecase number-or-command
+	  (number (etypecase number-or-command 
 		    (integer number-or-command)
 		    (symbol (ldap-command number-or-command)))))
-      (cond
+      (cond 
 	((< number 31)  (list (+ byte number)))
 	((< number 128) (list (+ byte +ber-multibyte-tag-number+) number))
 	(t (error "Length of tag exceeds maximum bounds (0-127).")))))
@@ -357,7 +357,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 	((< length 128) (list length))
 	((< length +max-int+)
 	 (let ((output (base10->base256 length)))
-	   (append (list (+ (length output) +ber-long-length-marker+))
+	   (append (list (+ (length output) +ber-long-length-marker+)) 
 		   output)))
 	(t (error "Length exceeds maximum bounds")))))
 
@@ -380,7 +380,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (define-constant +ldap-control-extension-paging+ "1.2.840.113556.1.4.319"
   "OID of the paging control.")
-
+  
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-constant +ldap-application-names+
     '((BindRequest           . 0)
@@ -403,15 +403,15 @@ NUMBER should be either an integer or LDAP application name as symbol."
       (AbandonRequest        . 16)
       (ExtendedRequest       . 23)
       (ExtendedResponse      . 24)))
-
+  
   (defun ldap-command (command)
     "Given a symbol naming an ldap command, return the command number."
     (cdr (assoc command +ldap-application-names+)))
-
+  
   (defun ldap-command-sym (number)
     "Given an application number, return the command name as symbol."
     (car (rassoc number +ldap-application-names+)))
-
+  
   (define-constant +ldap-result-codes+
       '((0  . (success			 "Success"))
 	(1  . (operationsError		 "Operations Error"))
@@ -463,7 +463,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
   (first (cdr (assoc code +ldap-result-codes+))))
 
 
-(define-constant +ldap-scope+
+(define-constant +ldap-scope+ 
   '((base . 0)
     (one  . 1)
     (sub  . 2)))
@@ -506,11 +506,11 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun ldap-modify-type (type)
   "Given a modify type, return the enumeration int."
   (cdr (assoc type +ldap-modify-type+)))
-
+	
 (defun ldap-filter-comparison-char (comparison-char-as-symbol)
   "Given a comparison character, return its integer enum value."
   (cdr (assoc comparison-char-as-symbol +ldap-filter-comparison-char+)))
-
+    
 (defun ldap-substring (type)
   "Given a substring type, return its integer choice value."
   (cdr (assoc type +ldap-substring+)))
@@ -520,15 +520,15 @@ NUMBER should be either an integer or LDAP application name as symbol."
 ;;;;
 
 ;;; writers.
-(define-constant +ber-bind-tag+
+(define-constant +ber-bind-tag+ 
   (ber-tag 'application 'constructed 'bindrequest))
-(define-constant +ber-add-tag+
+(define-constant +ber-add-tag+  
   (ber-tag 'application 'constructed 'addrequest))
-(define-constant +ber-del-tag+
+(define-constant +ber-del-tag+  
   (ber-tag 'application 'primitive 'delrequest))
-(define-constant +ber-moddn-tag+
+(define-constant +ber-moddn-tag+  
   (ber-tag 'application 'constructed 'modifydnrequest))
-(define-constant +ber-comp-tag+
+(define-constant +ber-comp-tag+ 
   (ber-tag 'application 'constructed 'comparerequest))
 (define-constant +ber-search-tag+
   (ber-tag 'application 'constructed 'searchrequest))
@@ -539,30 +539,30 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (define-constant +ber-modify-tag+
   (ber-tag 'application 'constructed 'modifyrequest))
 (define-constant +ber-controls-tag+
-    (car (ber-tag 'context 'constructed 0)))
+    (car (ber-tag 'context 'constructed 0)))                 
 
 ;;;; readers.
 (define-constant +ber-tag-controls+
-    (car (ber-tag 'context 'constructed 0)))
+    (car (ber-tag 'context 'constructed 0)))                 
 (define-constant +ber-tag-referral+
     (car (ber-tag 'context 'constructed 'searchrequest)))
 (define-constant +ber-tag-extendedresponse+
     (car (ber-tag 'application 'constructed 'extendedresponse)))
-(define-constant +ber-tag-ext-name+
+(define-constant +ber-tag-ext-name+  
     (car (ber-tag 'context 'primitive 10)))
-(define-constant +ber-tag-ext-val+
+(define-constant +ber-tag-ext-val+ 
     (car (ber-tag 'context 'primitive 11)))
-(define-constant +ber-tag-bool+
+(define-constant +ber-tag-bool+ 
     (car (ber-tag 'universal 'primitive #x01)))
-(define-constant +ber-tag-int+
+(define-constant +ber-tag-int+ 
     (car (ber-tag 'universal 'primitive #x02)))
-(define-constant +ber-tag-enum+
+(define-constant +ber-tag-enum+ 
     (car (ber-tag 'universal 'primitive #x0A)))
-(define-constant +ber-tag-str+
+(define-constant +ber-tag-str+ 
     (car (ber-tag 'universal 'primitive #x04)))
-(define-constant +ber-tag-seq+
+(define-constant +ber-tag-seq+ 
     (car (ber-tag 'universal 'constructed #x10)))
-(define-constant +ber-tag-set+
+(define-constant +ber-tag-set+ 
     (car (ber-tag 'universal 'constructed #x11)))
 (define-constant +ber-tag-sasl-res-creds+
     #x87)
@@ -611,14 +611,14 @@ NUMBER should be either an integer or LDAP application name as symbol."
   (let ((tag (ber-tag 'context 'primitive int)))
     (etypecase data
       (null (append tag (list #x00)))
-      (string  (if (string= data "")
+      (string  (if (string= data "") 
 		   (append tag (list #x00))
-		   (append tag (ber-length data)
+		   (append tag (ber-length data) 
 			   (string->char-code-list data))))
       (integer (seq-integer data))
       (boolean (seq-boolean data))
       (symbol  (let ((str (symbol-name data)))
-		 (append tag (ber-length str)
+		 (append tag (ber-length str) 
 			 (string->char-code-list str)))))))
 
 (defun seq-constructed-choice (int &optional data)
@@ -631,7 +631,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 		(append tag len val)))
       (sequence (let ((len (ber-length data)))
 		  (append tag len data))))))
-
+		     
 (defun seq-primitive-string (string)
   "BER encode a string/symbol for use in a primitive context."
   (assert (or (stringp string) (symbolp string) (typep string 'list)
@@ -646,9 +646,9 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (defun seq-attribute-alist (atts)
   "BER encode an entry object's attribute alist (for use in add)."
-  (seq-sequence (mapcan #'(lambda (i)
+  (seq-sequence (mapcan #'(lambda (i) 
 			    (seq-att-and-values (car i) (cdr i))) atts)))
-
+    
 (defun seq-attribute-list (att-list)
   "BER encode a list of attributes (for use in search)."
   (seq-sequence (mapcan #'seq-octet-string att-list)))
@@ -656,7 +656,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun seq-attribute-assertion (att val)
   "BER encode an ldap attribute assertion (for use in compare)."
   (seq-sequence (nconc (seq-octet-string att) (seq-octet-string val))))
-
+  
 (defun seq-attribute-value-assertion (att val)
   "BER encode an ldap attribute value assertion (for use in filters)."
   (nconc (seq-octet-string att) (seq-octet-string val)))
@@ -664,7 +664,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun seq-att-and-values (att vals)
   "BER encode an attribute and set of values (for use in modify)."
   (unless (listp vals) (setf vals (list vals)))
-  (seq-sequence (nconc (seq-octet-string att)
+  (seq-sequence (nconc (seq-octet-string att) 
 		       (seq-set (mapcan #'seq-octet-string vals)))))
 
 (defun ldap-filter-lexer (string)
@@ -697,7 +697,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
                  (when (not (zerop (length matched)))
                    (values terminal matched)))))
       (lambda ()
-        (block nil
+        (block nil 
           (macrolet ((try-match (pattern &body body)
                        (let ((gterminal (gensym "TERMINAL"))
                              (gvalue (gensym "VALUE")))
@@ -723,10 +723,10 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (yacc:define-parser *ldap-filter-parser*
   (:start-symbol filter)
-  (:terminals (lpar rpar semicolon colon and or not
+  (:terminals (lpar rpar semicolon colon and or not 
                     filtertype attr string))
   (:print-derives-epsilon nil)
-
+               
   ;; productions
   (filter
    (lpar filtercomp rpar (lambda (dummy1 val dummy2) (declare (ignore dummy1 dummy2)) val))
@@ -747,14 +747,14 @@ NUMBER should be either an integer or LDAP application name as symbol."
    #+nil extensible)
 
   (simple
-   (attr filtertype value
+   (attr filtertype value 
          (lambda (attr type value)
            (if (eq type '=)
                (cond ((string= value "*")
                       (list (intern "=*") attr))
                      ((position #\* value :test #'char=)
                       (list (intern "SUBSTRING") attr value))
-                     (t
+                     (t                      
                       (list type attr value)))
              (list type attr value)))))
 
@@ -791,23 +791,23 @@ NUMBER should be either an integer or LDAP application name as symbol."
      ((or (eq '&  op) (eq '\| op))
       (seq-constructed-choice (ldap-filter-comparison-char op)
                               (mapcan #'seq-filter (cdr filter))))
-     ((eq '=* op) (seq-primitive-choice
+     ((eq '=* op) (seq-primitive-choice 
                    (ldap-filter-comparison-char op) (second filter)))
      ((or (eq '= op)
           (eq '<= op) (eq '>= op) (eq '~= op))
-      (seq-constructed-choice (ldap-filter-comparison-char op)
+      (seq-constructed-choice (ldap-filter-comparison-char op) 
                               (seq-attribute-value-assertion
                                (second filter) (third filter))))
      ((eq 'substring op)
       (seq-constructed-choice (ldap-filter-comparison-char 'substring)
                               (append (seq-octet-string (second filter))
                                       (seq-substrings (third filter)))))
-     (t (error 'ldap-filter-error
+     (t (error 'ldap-filter-error 
                :mesg "unable to determine operator." :filter filter)))))
 
 (defun seq-substrings (value)
   "Given a search value with *s in it, return a BER encoded list."
-  (let ((list (etypecase value
+  (let ((list (etypecase value 
 		  (symbol (split-substring (symbol-name value)))
 		  (string (split-substring value))))
 	(initial ()) (any ()) (final ()))
@@ -821,7 +821,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
     (setf list (butlast list))
     (when (> (length list) 0)         ; any
       (dolist (i (remove "*" list :test #'string=))
-	(setf any (append any (seq-primitive-choice
+	(setf any (append any (seq-primitive-choice 
 			       (ldap-substring 'any) i)))))
     (seq-sequence (nconc initial any final))))
 
@@ -835,7 +835,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 ;;;;
 
 (defclass referrer ()
-  ((url :initarg :url
+  ((url :initarg :url 
 	:initform (error "No URL specified")
 	:type string
 	:accessor url)))
@@ -878,7 +878,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
     (multiple-value-bind (old-rdn old-rdn-parts) (rdn-from-dn (dn entry))
       (declare (ignore old-rdn))
       (del-attr entry (first old-rdn-parts) (second old-rdn-parts)))
-    (setf (dn entry) dn
+    (setf (dn entry) dn  
 	  (rdn entry) new-rdn)
     (multiple-value-bind (new-rdn new-rdn-parts) (rdn-from-dn (dn entry))
       (declare (ignore new-rdn))
@@ -887,13 +887,13 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defmethod attr-value ((entry entry) attr)
   "Given an entry object and attr name (symbol), return list of values."
   (let ((val (cdr (assoc attr (attrs entry)))))
-    (cond
+    (cond 
       ((null val) nil)
       ((consp val) val)
       (t (list val)))))
 
 (defmethod attr-value ((entry entry) (attrs list))
-  "Given an entry object and list of attr names (as symbols),
+  "Given an entry object and list of attr names (as symbols), 
 return list of lists of attributes."
   (mapcar #'(lambda (attr) (attr-value entry attr)) attrs))
 
@@ -915,10 +915,10 @@ return list of lists of attributes."
       (setf old-val (remove-if #'(lambda (x) (string= val x)) old-val)))
     (if (or (null (car old-val))
 	    (null (car new-val)))
-	(setf (attrs entry)
+	(setf (attrs entry) 
 	      (remove-if #'(lambda (x) (eq (car x) attr)) (attrs entry)))
 	(replace-attr entry attr old-val))))
-
+	      
 (defmethod replace-attr ((entry entry) attr vals)
   "Replace attribute values from entry object, do not update LDAP"
   (let ((vals (remove-if #'null vals)))
@@ -942,13 +942,13 @@ return list of lists of attributes."
   (:documentation "Condition that is signalled when a binary field is being parsed as a string"))
 
 (defun list-entries-to-string (key list)
-  (handler-case
+  (handler-case 
       (mapcar #'char-code-vec->string list)
     (error ()
       (error 'probably-binary-field-error :key key))))
 
 (defun attrs-from-list (x)
-  (restart-case
+  (restart-case 
       (let* ((key (char-code-vec->string (car x)))
              (value (restart-case
                         (if (attribute-binary-p key)
@@ -992,7 +992,7 @@ return list of lists of attributes."
                      (make-array (- end start)
                                  :element-type '(unsigned-byte 8)
                                  :displaced-to vec :displaced-index-offset (+ ptr start))))))
-
+            
 (defmethod pop-byte ((response-vec response-vec))
   (with-slots (vec ptr) response-vec
     (assert (< ptr (length vec)))
@@ -1025,22 +1025,22 @@ return list of lists of attributes."
 	   :accessor host)
    (port   :initarg :port
 	   :initform +ldap-port-no-ssl+
-	   :type integer
+	   :type integer 
 	   :accessor port)
    (sslflag :initarg :sslflag
 	    :initform nil
 	    :type symbol
 	    :accessor sslflag)
-   (user   :initarg :user
+   (user   :initarg :user 
 	   :initform ""
-	   :type string
+	   :type string 
 	   :accessor user)
-   (pass   :initarg :pass
+   (pass   :initarg :pass 
 	   :initform ""
-	   :type string
+	   :type string 
 	   :accessor pass)
-   (ldapstream :initarg :ldapstream
-	   :initform nil
+   (ldapstream :initarg :ldapstream  
+	   :initform nil 
 	   :type (or null stream)
 	   :accessor ldapstream)
    (ldapsock :initarg :ldapsock
@@ -1064,17 +1064,17 @@ return list of lists of attributes."
                  :accessor wrap-packets
                  :documentation "NIL means no wrapping. :CONF
 indicates encryption. Other values means plain wrapping.")
-   (mesg   :initarg :mesg
-	   :initform 0
-	   :type integer
+   (mesg   :initarg :mesg 
+	   :initform 0 
+	   :type integer 
 	   :accessor mesg)
    (debugflag  :initarg :debugflag
-	       :initform nil
-	       :type symbol
+	       :initform nil 
+	       :type symbol 
 	       :accessor debugflag)
-   (base   :initarg :base
-	   :initform nil
-	   :type (or null string)
+   (base   :initarg :base 
+	   :initform nil 
+	   :type (or null string) 
 	   :accessor base)
    (response :initarg :response
 	     :accessor response)
@@ -1113,7 +1113,7 @@ indicates encryption. Other values means plain wrapping.")
         (setq *wrap-fn* (find-symbol-in-package-or-error "WRAP" package))
         (setq *unwrap-fn* (find-symbol-in-package-or-error "UNWRAP" package))))
     (make-instance 'ldap :host host :port port :user user :sslflag sslflag
-                   :pass pass :debugflag debug :base base
+                   :pass pass :debugflag debug :base base 
                    :reuse-connection reuse-connection :sasl sasl)))
 
 (defmacro debug-mesg (ldap message)
@@ -1129,11 +1129,11 @@ indicates encryption. Other values means plain wrapping.")
 If the port number is 636 or the SSLflag is not null, the stream
 will be made with CL+SSL."
   (let ((existing-stream (ldapstream ldap)))
-    (unless (and (streamp existing-stream)
+    (unless (and (streamp existing-stream) 
 		 (open-stream-p existing-stream))
       (let* ((sock (usocket:socket-connect (host ldap) (port ldap)
 					   :element-type '(unsigned-byte 8)))
-	     (stream
+	     (stream 
 	      (if (or (sslflag ldap) (= (port ldap) 636))
 		  (cl+ssl:make-ssl-client-stream (usocket:socket-stream sock))
 		  (usocket:socket-stream sock))))
@@ -1189,7 +1189,7 @@ will be made with CL+SSL."
         (setf (ldapstream ldap) nil)
         (close existing-stream)))))
 
-(defmethod possibly-reopen-and-rebind ((ldap ldap)
+(defmethod possibly-reopen-and-rebind ((ldap ldap) 
 				       &optional (absolutely-no-bind nil))
   "Take appropriate reopen or rebind actions based on the reuse-connection attr.
 If the attribute is nil, do nothing; if t, reopen; and, if bind, rebind.
@@ -1197,7 +1197,7 @@ This function exists to help the poor saps (read: me) with very fast idletimeout
 settings on their LDAP servers."
   (debug-mesg ldap "reusing connection...")
   (let (stream)
-    (when (reuse-connection ldap)
+    (when (reuse-connection ldap) 
       (close-stream ldap)
       (setf stream (get-stream ldap)))
     (when (and (not absolutely-no-bind)
@@ -1300,10 +1300,10 @@ only for its side effects."
           (dotimes (i message-length)
             (setf (aref vec i) (read-wrapped-byte ldap)))
           (debug-mesg ldap (format nil *hex-print* "From LDAP:"
-                                   (append (list initial-byte) bytes-read
+                                   (append (list initial-byte) bytes-read 
                                            (coerce vec 'list)))))
         (setf (response ldap) response-vec)))
-    (let ((response-minus-message-number
+    (let ((response-minus-message-number 
            (check-message-number (response ldap) (mesg ldap))))
       (cond
        ((null response-minus-message-number) (receive-message ldap))
@@ -1320,7 +1320,7 @@ and throw an error if it's anything else."
         (ignore-errors
           (close-stream ldap))
         (error 'ldap-response-error :code status :msg (char-code-vec->string message)))
-      (error 'ldap-error
+      (error 'ldap-error 
              :mesg (format nil "Received unhandled extended response: ~A~%"
                            content)))))
 
@@ -1372,15 +1372,15 @@ and throw an error if it's anything else."
                (process-response-controls ldap controls))))
          (setf (results-pending-p ldap) nil)
 	 (setf received-content nil))
-	((eq appname 'extendedresponse)
+	((eq appname 'extendedresponse) 
 	 (handle-extended-response ldap content)
 	 (push content received-content)
 	 (setf (results-pending-p ldap) nil))
-	(t
+	(t 
 	 (push content received-content)
 	 (setf (results-pending-p ldap) nil))))
     received-content))
-
+	
 (defmethod process-message ((ldap ldap) message &key (success 'success))
   "Send a simple request to LDAP and return three values:
 T or NIL, the LDAP response code (as a readable string), and any message
@@ -1396,7 +1396,7 @@ the directory server returned."
 	 (rc (if (eq code-sym success) t nil)))
     (values rc code-sym msg)))
 
-;;;;
+;;;;  
 ;;;; ldap user-level commands.
 ;;;;
 
@@ -1525,8 +1525,8 @@ the directory server returned."
 (defmethod abandon ((ldap ldap))
   "Abandon the request and suck any data off the incoming stream.
 Because the receive-message will keep receiving messages until it gets
-one with the correct message number, no action needs to be taken here to
-clear the incoming data off the line.  It's unclear that's the best
+one with the correct message number, no action needs to be taken here to 
+clear the incoming data off the line.  It's unclear that's the best 
 solution, but (clear-input) doesn't actually work and trying to read non-
 existent bytes blocks..."
   (send-message ldap (msg-abandon ldap) nil))
@@ -1539,7 +1539,7 @@ existent bytes blocks..."
 (defmethod add ((entry entry) (ldap ldap))
   "Add an entry object to LDAP; error unless successful."
   (multiple-value-bind (res code msg) (add ldap entry)
-    (or res (error 'ldap-response-error
+    (or res (error 'ldap-response-error 
 		   :mesg "Cannot add entry to LDAP directory."
 		   :dn (dn entry) :code code :msg msg))))
 
@@ -1571,7 +1571,7 @@ existent bytes blocks..."
   "Modify the RDN of an LDAP entry."
   (multiple-value-bind (res code msg)
       (moddn ldap dn new-rdn :delete-old delete-old :new-sup new-sup)
-    (or res (error 'ldap-response-error
+    (or res (error 'ldap-response-error 
 		   :mesg "Cannot modify RDN in the LDAP directory."
 		   :dn dn :code code :msg msg))))
 
@@ -1602,7 +1602,7 @@ existent bytes blocks..."
   "Modify entry attributes in ldap, update the entry object.
 LIST-OF-MODS is a list of (type att val) triples."
   (multiple-value-bind (res code msg) (modify ldap entry list-of-mods)
-    (when (null res)
+    (when (null res) 
       (error 'ldap-response-error
 	     :mesg "Cannot modify entry in the LDAP directory."
 	     :dn (dn entry) :code code :msg msg))
@@ -1613,13 +1613,13 @@ LIST-OF-MODS is a list of (type att val) triples."
 	((eq (car i) 'add) (add-attr entry (second i) (third i)))
 	(t (replace-attr entry (second i) (third i)))))))
 
-(defmethod search ((ldap ldap) filter &key base (scope 'sub)
-		   (deref 'never) (size-limit 0) (time-limit 0)
+(defmethod search ((ldap ldap) filter &key base (scope 'sub) 
+		   (deref 'never) (size-limit 0) (time-limit 0) 
 		   types-only attributes (paging-size nil))
   "Search the LDAP directory."
   (flet ((search-i (ldap filter base scope deref size-limit time-limit types-only attributes paging-cookie)
            (possibly-reopen-and-rebind ldap)
-           (send-message ldap (msg-search filter base scope deref size-limit
+           (send-message ldap (msg-search filter base scope deref size-limit 
                                           time-limit types-only attributes paging-size paging-cookie))
            (receive-message ldap)
            (parse-ldap-message ldap)))
@@ -1638,7 +1638,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   (flet ((next-search-result-i ()
            (if (results-pending-p ldap)
              (let ((pending-entry (entry-buffer ldap)))
-               (cond
+               (cond 
                 ((not (null pending-entry))
                  (setf (entry-buffer ldap) nil)
                  pending-entry)
@@ -1657,7 +1657,7 @@ LIST-OF-MODS is a list of (type att val) triples."
     `(let ((,ldap ,(second search-form))
  	   (,count 0))
       ,search-form
-      (do ((,var (next-search-result ,ldap)
+      (do ((,var (next-search-result ,ldap) 
  		 (next-search-result ,ldap)))
  	  ((null ,var))
  	(incf ,count)
@@ -1698,7 +1698,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   "Return the sequence of bytes representing a delete message."
   (let ((dn (seq-primitive-string (dn dn-or-entry))))
     (ber-msg +ber-del-tag+ dn)))
-
+	
 (defun msg-moddn (dn-or-entry new-rdn delete-old new-sup)
   "Return the sequence of bytes representing a moddn message."
   (let ((dn  (seq-octet-string (dn dn-or-entry)))
@@ -1716,8 +1716,8 @@ LIST-OF-MODS is a list of (type att val) triples."
 (defun msg-modify (dn-or-entry mod-list)
   "Return the sequence of bytes representing a modify message."
   (let ((dn (seq-octet-string (dn dn-or-entry)))
-	(mods
-	 (mapcan #'(lambda (x) (seq-sequence
+	(mods 
+	 (mapcan #'(lambda (x) (seq-sequence 
 				(nconc
 				 (seq-enumerated (ldap-modify-type (first x)))
 				 (seq-att-and-values (second x) (third x)))))
@@ -1733,11 +1733,7 @@ LIST-OF-MODS is a list of (type att val) triples."
 	(size   (seq-integer size))
 	(time   (seq-integer time))
 	(types  (seq-boolean types))
-        (attrs
-          (seq-attribute-list (case attrs
-                                ((nil) '("1.1")) ; No attributes
-                                ((t)   nil)      ; All attributes
-                                (t     attrs)))) ; those requested
+	(attrs  (seq-attribute-list attrs))
         (controls
          (when (and paging-size
                     (zerop size))
@@ -1750,7 +1746,7 @@ LIST-OF-MODS is a list of (type att val) triples."
                                                         (nconc
                                                          (seq-integer paging-size)
                                                          (seq-octet-string paging-cookie))))))))))
-    (ber-msg +ber-search-tag+
+    (ber-msg +ber-search-tag+ 
 	     (append base scope deref size time types filter attrs controls))))
 
 ;;;;
@@ -1760,7 +1756,7 @@ LIST-OF-MODS is a list of (type att val) triples."
 (defun read-decoder (response)
   "Decode a BER encoded response (minus initial byte & length) from LDAP."
   (let ((appname (ldap-command-sym (read-app-number (pop-byte response)))))
-    (read-length response) ;; skip length
+    (read-length response) ;; skip length 
     (values (read-generic response) appname)))
 
 (defun read-controls (message)
@@ -1820,7 +1816,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   "Read an octet vector from the message."
   (let ((length (read-length message)))
     (with-slots (vec ptr) message
-      (prog1
+      (prog1 
           (subseq vec ptr (+ ptr length))
         (incf ptr length)))))
 
@@ -1837,7 +1833,7 @@ LIST-OF-MODS is a list of (type att val) triples."
 
 (defun read-message-number (response expected-mesg-number)
   "Read message number from the seq, return t or nil."
-  (pop-byte response) ; pop tag byte for
+  (pop-byte response) ; pop tag byte for 
   (let ((value (read-integer response)))
     (or (zerop value) ; 0 is unsolicited notification.
         (= value expected-mesg-number))))

--- a/trivial-ldap.lisp
+++ b/trivial-ldap.lisp
@@ -1733,7 +1733,11 @@ LIST-OF-MODS is a list of (type att val) triples."
 	(size   (seq-integer size))
 	(time   (seq-integer time))
 	(types  (seq-boolean types))
-	(attrs  (seq-attribute-list attrs))
+        (attrs
+          (seq-attribute-list (case attrs
+                                ((nil) '("1.1")) ; No attributes
+                                ((t)   nil)      ; All attributes
+                                (t     attrs)))) ; those requested
         (controls
          (when (and paging-size
                     (zerop size))

--- a/trivial-ldap.lisp
+++ b/trivial-ldap.lisp
@@ -1,5 +1,5 @@
-;;;; TRIVIAL-LDAP -- a one file, all lisp client implementation of
-;;;; parts of RFC 2261.  
+;;;; trivial-ldap.lisp -- a one file, all lisp client implementation of
+;;;; parts of RFC 2261.
 
 ;;;; Please see the trivial-ldap.html file for documentation and limitations.
 
@@ -57,7 +57,7 @@
 	   :reader filter
 	   :initform "Not Supplied"))
   (:report (lambda (c stream)
-	     (format stream "Filter Error: ~A~%Supplied Filter: ~A~%" 
+	     (format stream "Filter Error: ~A~%Supplied Filter: ~A~%"
 		     (mesg c) (filter c)))))
 
 (define-condition ldap-connection-error (ldap-error)
@@ -119,7 +119,7 @@
 (defun base10->base256 (int)
   "Return representation of an integer as a list of base 256 'digits'."
   (assert (and (integerp int) (>= int 0)))
-  (or 
+  (or
    (do ((i 0 (+ i 8))
 	(j int (ash j -8))
 	(result nil (cons (logand #xFF j) result)))
@@ -230,13 +230,13 @@
 
 (defun string->char-code-list (string)
   "Convert a string into a list of bytes."
-   (let ((string (etypecase string 
+   (let ((string (etypecase string
  		  (string string)
  		  (symbol (symbol-name string)))))
      #-(or allegro ccl sbcl lispworks)
      (map 'list #'char-code string)
      #+ccl
-     (coerce 
+     (coerce
       (ccl::encode-string-to-octets string :external-format :utf-8) 'list)
      #+sbcl
      (coerce (sb-ext:string-to-octets string :external-format :utf-8) 'list)
@@ -306,20 +306,20 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-constant +max-int+ (- (expt 2 31) 1)
     "As defined by the LDAP RFC.")
-  
+
   (define-constant +ber-class-id+
       '((universal   . #b00000000) (application . #b01000000)
 	(context     . #b10000000) (private     . #b11000000)))
-  
+
   (define-constant +ber-p/c-bit+
       '((primitive   . #b00000000) (constructed . #b00100000)))
-  
+
   (define-constant +ber-multibyte-tag-number+ #b00011111
     "Flag indicating tag number requires > 1 byte")
-  
+
   (define-constant +ber-long-length-marker+   #b10000000
     "Flag indicating more tag number bytes follow")
-  
+
   (defun ber-class-id (class)
     "Return the bits to construct a BER tag of type class."
     (or (cdr (assoc class +ber-class-id+))
@@ -340,10 +340,10 @@ CLASS should be the symbol universal, applicaiton, context, or private.
 P/C should be the symbol primitive or constructed.
 NUMBER should be either an integer or LDAP application name as symbol."
     (let ((byte (ber-tag-type class p/c))
-	  (number (etypecase number-or-command 
+	  (number (etypecase number-or-command
 		    (integer number-or-command)
 		    (symbol (ldap-command number-or-command)))))
-      (cond 
+      (cond
 	((< number 31)  (list (+ byte number)))
 	((< number 128) (list (+ byte +ber-multibyte-tag-number+) number))
 	(t (error "Length of tag exceeds maximum bounds (0-127).")))))
@@ -357,7 +357,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 	((< length 128) (list length))
 	((< length +max-int+)
 	 (let ((output (base10->base256 length)))
-	   (append (list (+ (length output) +ber-long-length-marker+)) 
+	   (append (list (+ (length output) +ber-long-length-marker+))
 		   output)))
 	(t (error "Length exceeds maximum bounds")))))
 
@@ -380,7 +380,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (define-constant +ldap-control-extension-paging+ "1.2.840.113556.1.4.319"
   "OID of the paging control.")
-  
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-constant +ldap-application-names+
     '((BindRequest           . 0)
@@ -403,15 +403,15 @@ NUMBER should be either an integer or LDAP application name as symbol."
       (AbandonRequest        . 16)
       (ExtendedRequest       . 23)
       (ExtendedResponse      . 24)))
-  
+
   (defun ldap-command (command)
     "Given a symbol naming an ldap command, return the command number."
     (cdr (assoc command +ldap-application-names+)))
-  
+
   (defun ldap-command-sym (number)
     "Given an application number, return the command name as symbol."
     (car (rassoc number +ldap-application-names+)))
-  
+
   (define-constant +ldap-result-codes+
       '((0  . (success			 "Success"))
 	(1  . (operationsError		 "Operations Error"))
@@ -463,7 +463,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
   (first (cdr (assoc code +ldap-result-codes+))))
 
 
-(define-constant +ldap-scope+ 
+(define-constant +ldap-scope+
   '((base . 0)
     (one  . 1)
     (sub  . 2)))
@@ -506,11 +506,11 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun ldap-modify-type (type)
   "Given a modify type, return the enumeration int."
   (cdr (assoc type +ldap-modify-type+)))
-	
+
 (defun ldap-filter-comparison-char (comparison-char-as-symbol)
   "Given a comparison character, return its integer enum value."
   (cdr (assoc comparison-char-as-symbol +ldap-filter-comparison-char+)))
-    
+
 (defun ldap-substring (type)
   "Given a substring type, return its integer choice value."
   (cdr (assoc type +ldap-substring+)))
@@ -520,15 +520,15 @@ NUMBER should be either an integer or LDAP application name as symbol."
 ;;;;
 
 ;;; writers.
-(define-constant +ber-bind-tag+ 
+(define-constant +ber-bind-tag+
   (ber-tag 'application 'constructed 'bindrequest))
-(define-constant +ber-add-tag+  
+(define-constant +ber-add-tag+
   (ber-tag 'application 'constructed 'addrequest))
-(define-constant +ber-del-tag+  
+(define-constant +ber-del-tag+
   (ber-tag 'application 'primitive 'delrequest))
-(define-constant +ber-moddn-tag+  
+(define-constant +ber-moddn-tag+
   (ber-tag 'application 'constructed 'modifydnrequest))
-(define-constant +ber-comp-tag+ 
+(define-constant +ber-comp-tag+
   (ber-tag 'application 'constructed 'comparerequest))
 (define-constant +ber-search-tag+
   (ber-tag 'application 'constructed 'searchrequest))
@@ -539,30 +539,30 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (define-constant +ber-modify-tag+
   (ber-tag 'application 'constructed 'modifyrequest))
 (define-constant +ber-controls-tag+
-    (car (ber-tag 'context 'constructed 0)))                 
+    (car (ber-tag 'context 'constructed 0)))
 
 ;;;; readers.
 (define-constant +ber-tag-controls+
-    (car (ber-tag 'context 'constructed 0)))                 
+    (car (ber-tag 'context 'constructed 0)))
 (define-constant +ber-tag-referral+
     (car (ber-tag 'context 'constructed 'searchrequest)))
 (define-constant +ber-tag-extendedresponse+
     (car (ber-tag 'application 'constructed 'extendedresponse)))
-(define-constant +ber-tag-ext-name+  
+(define-constant +ber-tag-ext-name+
     (car (ber-tag 'context 'primitive 10)))
-(define-constant +ber-tag-ext-val+ 
+(define-constant +ber-tag-ext-val+
     (car (ber-tag 'context 'primitive 11)))
-(define-constant +ber-tag-bool+ 
+(define-constant +ber-tag-bool+
     (car (ber-tag 'universal 'primitive #x01)))
-(define-constant +ber-tag-int+ 
+(define-constant +ber-tag-int+
     (car (ber-tag 'universal 'primitive #x02)))
-(define-constant +ber-tag-enum+ 
+(define-constant +ber-tag-enum+
     (car (ber-tag 'universal 'primitive #x0A)))
-(define-constant +ber-tag-str+ 
+(define-constant +ber-tag-str+
     (car (ber-tag 'universal 'primitive #x04)))
-(define-constant +ber-tag-seq+ 
+(define-constant +ber-tag-seq+
     (car (ber-tag 'universal 'constructed #x10)))
-(define-constant +ber-tag-set+ 
+(define-constant +ber-tag-set+
     (car (ber-tag 'universal 'constructed #x11)))
 (define-constant +ber-tag-sasl-res-creds+
     #x87)
@@ -611,14 +611,14 @@ NUMBER should be either an integer or LDAP application name as symbol."
   (let ((tag (ber-tag 'context 'primitive int)))
     (etypecase data
       (null (append tag (list #x00)))
-      (string  (if (string= data "") 
+      (string  (if (string= data "")
 		   (append tag (list #x00))
-		   (append tag (ber-length data) 
+		   (append tag (ber-length data)
 			   (string->char-code-list data))))
       (integer (seq-integer data))
       (boolean (seq-boolean data))
       (symbol  (let ((str (symbol-name data)))
-		 (append tag (ber-length str) 
+		 (append tag (ber-length str)
 			 (string->char-code-list str)))))))
 
 (defun seq-constructed-choice (int &optional data)
@@ -631,7 +631,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 		(append tag len val)))
       (sequence (let ((len (ber-length data)))
 		  (append tag len data))))))
-		     
+
 (defun seq-primitive-string (string)
   "BER encode a string/symbol for use in a primitive context."
   (assert (or (stringp string) (symbolp string) (typep string 'list)
@@ -646,9 +646,9 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (defun seq-attribute-alist (atts)
   "BER encode an entry object's attribute alist (for use in add)."
-  (seq-sequence (mapcan #'(lambda (i) 
+  (seq-sequence (mapcan #'(lambda (i)
 			    (seq-att-and-values (car i) (cdr i))) atts)))
-    
+
 (defun seq-attribute-list (att-list)
   "BER encode a list of attributes (for use in search)."
   (seq-sequence (mapcan #'seq-octet-string att-list)))
@@ -656,7 +656,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun seq-attribute-assertion (att val)
   "BER encode an ldap attribute assertion (for use in compare)."
   (seq-sequence (nconc (seq-octet-string att) (seq-octet-string val))))
-  
+
 (defun seq-attribute-value-assertion (att val)
   "BER encode an ldap attribute value assertion (for use in filters)."
   (nconc (seq-octet-string att) (seq-octet-string val)))
@@ -664,7 +664,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defun seq-att-and-values (att vals)
   "BER encode an attribute and set of values (for use in modify)."
   (unless (listp vals) (setf vals (list vals)))
-  (seq-sequence (nconc (seq-octet-string att) 
+  (seq-sequence (nconc (seq-octet-string att)
 		       (seq-set (mapcan #'seq-octet-string vals)))))
 
 (defun ldap-filter-lexer (string)
@@ -697,7 +697,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
                  (when (not (zerop (length matched)))
                    (values terminal matched)))))
       (lambda ()
-        (block nil 
+        (block nil
           (macrolet ((try-match (pattern &body body)
                        (let ((gterminal (gensym "TERMINAL"))
                              (gvalue (gensym "VALUE")))
@@ -723,10 +723,10 @@ NUMBER should be either an integer or LDAP application name as symbol."
 
 (yacc:define-parser *ldap-filter-parser*
   (:start-symbol filter)
-  (:terminals (lpar rpar semicolon colon and or not 
+  (:terminals (lpar rpar semicolon colon and or not
                     filtertype attr string))
   (:print-derives-epsilon nil)
-               
+
   ;; productions
   (filter
    (lpar filtercomp rpar (lambda (dummy1 val dummy2) (declare (ignore dummy1 dummy2)) val))
@@ -747,14 +747,14 @@ NUMBER should be either an integer or LDAP application name as symbol."
    #+nil extensible)
 
   (simple
-   (attr filtertype value 
+   (attr filtertype value
          (lambda (attr type value)
            (if (eq type '=)
                (cond ((string= value "*")
                       (list (intern "=*") attr))
                      ((position #\* value :test #'char=)
                       (list (intern "SUBSTRING") attr value))
-                     (t                      
+                     (t
                       (list type attr value)))
              (list type attr value)))))
 
@@ -791,23 +791,23 @@ NUMBER should be either an integer or LDAP application name as symbol."
      ((or (eq '&  op) (eq '\| op))
       (seq-constructed-choice (ldap-filter-comparison-char op)
                               (mapcan #'seq-filter (cdr filter))))
-     ((eq '=* op) (seq-primitive-choice 
+     ((eq '=* op) (seq-primitive-choice
                    (ldap-filter-comparison-char op) (second filter)))
      ((or (eq '= op)
           (eq '<= op) (eq '>= op) (eq '~= op))
-      (seq-constructed-choice (ldap-filter-comparison-char op) 
+      (seq-constructed-choice (ldap-filter-comparison-char op)
                               (seq-attribute-value-assertion
                                (second filter) (third filter))))
      ((eq 'substring op)
       (seq-constructed-choice (ldap-filter-comparison-char 'substring)
                               (append (seq-octet-string (second filter))
                                       (seq-substrings (third filter)))))
-     (t (error 'ldap-filter-error 
+     (t (error 'ldap-filter-error
                :mesg "unable to determine operator." :filter filter)))))
 
 (defun seq-substrings (value)
   "Given a search value with *s in it, return a BER encoded list."
-  (let ((list (etypecase value 
+  (let ((list (etypecase value
 		  (symbol (split-substring (symbol-name value)))
 		  (string (split-substring value))))
 	(initial ()) (any ()) (final ()))
@@ -821,7 +821,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
     (setf list (butlast list))
     (when (> (length list) 0)         ; any
       (dolist (i (remove "*" list :test #'string=))
-	(setf any (append any (seq-primitive-choice 
+	(setf any (append any (seq-primitive-choice
 			       (ldap-substring 'any) i)))))
     (seq-sequence (nconc initial any final))))
 
@@ -835,7 +835,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
 ;;;;
 
 (defclass referrer ()
-  ((url :initarg :url 
+  ((url :initarg :url
 	:initform (error "No URL specified")
 	:type string
 	:accessor url)))
@@ -878,7 +878,7 @@ NUMBER should be either an integer or LDAP application name as symbol."
     (multiple-value-bind (old-rdn old-rdn-parts) (rdn-from-dn (dn entry))
       (declare (ignore old-rdn))
       (del-attr entry (first old-rdn-parts) (second old-rdn-parts)))
-    (setf (dn entry) dn  
+    (setf (dn entry) dn
 	  (rdn entry) new-rdn)
     (multiple-value-bind (new-rdn new-rdn-parts) (rdn-from-dn (dn entry))
       (declare (ignore new-rdn))
@@ -887,13 +887,13 @@ NUMBER should be either an integer or LDAP application name as symbol."
 (defmethod attr-value ((entry entry) attr)
   "Given an entry object and attr name (symbol), return list of values."
   (let ((val (cdr (assoc attr (attrs entry)))))
-    (cond 
+    (cond
       ((null val) nil)
       ((consp val) val)
       (t (list val)))))
 
 (defmethod attr-value ((entry entry) (attrs list))
-  "Given an entry object and list of attr names (as symbols), 
+  "Given an entry object and list of attr names (as symbols),
 return list of lists of attributes."
   (mapcar #'(lambda (attr) (attr-value entry attr)) attrs))
 
@@ -915,10 +915,10 @@ return list of lists of attributes."
       (setf old-val (remove-if #'(lambda (x) (string= val x)) old-val)))
     (if (or (null (car old-val))
 	    (null (car new-val)))
-	(setf (attrs entry) 
+	(setf (attrs entry)
 	      (remove-if #'(lambda (x) (eq (car x) attr)) (attrs entry)))
 	(replace-attr entry attr old-val))))
-	      
+
 (defmethod replace-attr ((entry entry) attr vals)
   "Replace attribute values from entry object, do not update LDAP"
   (let ((vals (remove-if #'null vals)))
@@ -942,13 +942,13 @@ return list of lists of attributes."
   (:documentation "Condition that is signalled when a binary field is being parsed as a string"))
 
 (defun list-entries-to-string (key list)
-  (handler-case 
+  (handler-case
       (mapcar #'char-code-vec->string list)
     (error ()
       (error 'probably-binary-field-error :key key))))
 
 (defun attrs-from-list (x)
-  (restart-case 
+  (restart-case
       (let* ((key (char-code-vec->string (car x)))
              (value (restart-case
                         (if (attribute-binary-p key)
@@ -992,7 +992,7 @@ return list of lists of attributes."
                      (make-array (- end start)
                                  :element-type '(unsigned-byte 8)
                                  :displaced-to vec :displaced-index-offset (+ ptr start))))))
-            
+
 (defmethod pop-byte ((response-vec response-vec))
   (with-slots (vec ptr) response-vec
     (assert (< ptr (length vec)))
@@ -1025,22 +1025,22 @@ return list of lists of attributes."
 	   :accessor host)
    (port   :initarg :port
 	   :initform +ldap-port-no-ssl+
-	   :type integer 
+	   :type integer
 	   :accessor port)
    (sslflag :initarg :sslflag
 	    :initform nil
 	    :type symbol
 	    :accessor sslflag)
-   (user   :initarg :user 
+   (user   :initarg :user
 	   :initform ""
-	   :type string 
+	   :type string
 	   :accessor user)
-   (pass   :initarg :pass 
+   (pass   :initarg :pass
 	   :initform ""
-	   :type string 
+	   :type string
 	   :accessor pass)
-   (ldapstream :initarg :ldapstream  
-	   :initform nil 
+   (ldapstream :initarg :ldapstream
+	   :initform nil
 	   :type (or null stream)
 	   :accessor ldapstream)
    (ldapsock :initarg :ldapsock
@@ -1064,17 +1064,17 @@ return list of lists of attributes."
                  :accessor wrap-packets
                  :documentation "NIL means no wrapping. :CONF
 indicates encryption. Other values means plain wrapping.")
-   (mesg   :initarg :mesg 
-	   :initform 0 
-	   :type integer 
+   (mesg   :initarg :mesg
+	   :initform 0
+	   :type integer
 	   :accessor mesg)
    (debugflag  :initarg :debugflag
-	       :initform nil 
-	       :type symbol 
+	       :initform nil
+	       :type symbol
 	       :accessor debugflag)
-   (base   :initarg :base 
-	   :initform nil 
-	   :type (or null string) 
+   (base   :initarg :base
+	   :initform nil
+	   :type (or null string)
 	   :accessor base)
    (response :initarg :response
 	     :accessor response)
@@ -1113,7 +1113,7 @@ indicates encryption. Other values means plain wrapping.")
         (setq *wrap-fn* (find-symbol-in-package-or-error "WRAP" package))
         (setq *unwrap-fn* (find-symbol-in-package-or-error "UNWRAP" package))))
     (make-instance 'ldap :host host :port port :user user :sslflag sslflag
-                   :pass pass :debugflag debug :base base 
+                   :pass pass :debugflag debug :base base
                    :reuse-connection reuse-connection :sasl sasl)))
 
 (defmacro debug-mesg (ldap message)
@@ -1129,11 +1129,11 @@ indicates encryption. Other values means plain wrapping.")
 If the port number is 636 or the SSLflag is not null, the stream
 will be made with CL+SSL."
   (let ((existing-stream (ldapstream ldap)))
-    (unless (and (streamp existing-stream) 
+    (unless (and (streamp existing-stream)
 		 (open-stream-p existing-stream))
       (let* ((sock (usocket:socket-connect (host ldap) (port ldap)
 					   :element-type '(unsigned-byte 8)))
-	     (stream 
+	     (stream
 	      (if (or (sslflag ldap) (= (port ldap) 636))
 		  (cl+ssl:make-ssl-client-stream (usocket:socket-stream sock))
 		  (usocket:socket-stream sock))))
@@ -1189,7 +1189,7 @@ will be made with CL+SSL."
         (setf (ldapstream ldap) nil)
         (close existing-stream)))))
 
-(defmethod possibly-reopen-and-rebind ((ldap ldap) 
+(defmethod possibly-reopen-and-rebind ((ldap ldap)
 				       &optional (absolutely-no-bind nil))
   "Take appropriate reopen or rebind actions based on the reuse-connection attr.
 If the attribute is nil, do nothing; if t, reopen; and, if bind, rebind.
@@ -1197,7 +1197,7 @@ This function exists to help the poor saps (read: me) with very fast idletimeout
 settings on their LDAP servers."
   (debug-mesg ldap "reusing connection...")
   (let (stream)
-    (when (reuse-connection ldap) 
+    (when (reuse-connection ldap)
       (close-stream ldap)
       (setf stream (get-stream ldap)))
     (when (and (not absolutely-no-bind)
@@ -1300,10 +1300,10 @@ only for its side effects."
           (dotimes (i message-length)
             (setf (aref vec i) (read-wrapped-byte ldap)))
           (debug-mesg ldap (format nil *hex-print* "From LDAP:"
-                                   (append (list initial-byte) bytes-read 
+                                   (append (list initial-byte) bytes-read
                                            (coerce vec 'list)))))
         (setf (response ldap) response-vec)))
-    (let ((response-minus-message-number 
+    (let ((response-minus-message-number
            (check-message-number (response ldap) (mesg ldap))))
       (cond
        ((null response-minus-message-number) (receive-message ldap))
@@ -1320,7 +1320,7 @@ and throw an error if it's anything else."
         (ignore-errors
           (close-stream ldap))
         (error 'ldap-response-error :code status :msg (char-code-vec->string message)))
-      (error 'ldap-error 
+      (error 'ldap-error
              :mesg (format nil "Received unhandled extended response: ~A~%"
                            content)))))
 
@@ -1372,15 +1372,15 @@ and throw an error if it's anything else."
                (process-response-controls ldap controls))))
          (setf (results-pending-p ldap) nil)
 	 (setf received-content nil))
-	((eq appname 'extendedresponse) 
+	((eq appname 'extendedresponse)
 	 (handle-extended-response ldap content)
 	 (push content received-content)
 	 (setf (results-pending-p ldap) nil))
-	(t 
+	(t
 	 (push content received-content)
 	 (setf (results-pending-p ldap) nil))))
     received-content))
-	
+
 (defmethod process-message ((ldap ldap) message &key (success 'success))
   "Send a simple request to LDAP and return three values:
 T or NIL, the LDAP response code (as a readable string), and any message
@@ -1396,7 +1396,7 @@ the directory server returned."
 	 (rc (if (eq code-sym success) t nil)))
     (values rc code-sym msg)))
 
-;;;;  
+;;;;
 ;;;; ldap user-level commands.
 ;;;;
 
@@ -1525,8 +1525,8 @@ the directory server returned."
 (defmethod abandon ((ldap ldap))
   "Abandon the request and suck any data off the incoming stream.
 Because the receive-message will keep receiving messages until it gets
-one with the correct message number, no action needs to be taken here to 
-clear the incoming data off the line.  It's unclear that's the best 
+one with the correct message number, no action needs to be taken here to
+clear the incoming data off the line.  It's unclear that's the best
 solution, but (clear-input) doesn't actually work and trying to read non-
 existent bytes blocks..."
   (send-message ldap (msg-abandon ldap) nil))
@@ -1539,7 +1539,7 @@ existent bytes blocks..."
 (defmethod add ((entry entry) (ldap ldap))
   "Add an entry object to LDAP; error unless successful."
   (multiple-value-bind (res code msg) (add ldap entry)
-    (or res (error 'ldap-response-error 
+    (or res (error 'ldap-response-error
 		   :mesg "Cannot add entry to LDAP directory."
 		   :dn (dn entry) :code code :msg msg))))
 
@@ -1571,7 +1571,7 @@ existent bytes blocks..."
   "Modify the RDN of an LDAP entry."
   (multiple-value-bind (res code msg)
       (moddn ldap dn new-rdn :delete-old delete-old :new-sup new-sup)
-    (or res (error 'ldap-response-error 
+    (or res (error 'ldap-response-error
 		   :mesg "Cannot modify RDN in the LDAP directory."
 		   :dn dn :code code :msg msg))))
 
@@ -1602,7 +1602,7 @@ existent bytes blocks..."
   "Modify entry attributes in ldap, update the entry object.
 LIST-OF-MODS is a list of (type att val) triples."
   (multiple-value-bind (res code msg) (modify ldap entry list-of-mods)
-    (when (null res) 
+    (when (null res)
       (error 'ldap-response-error
 	     :mesg "Cannot modify entry in the LDAP directory."
 	     :dn (dn entry) :code code :msg msg))
@@ -1613,13 +1613,13 @@ LIST-OF-MODS is a list of (type att val) triples."
 	((eq (car i) 'add) (add-attr entry (second i) (third i)))
 	(t (replace-attr entry (second i) (third i)))))))
 
-(defmethod search ((ldap ldap) filter &key base (scope 'sub) 
-		   (deref 'never) (size-limit 0) (time-limit 0) 
+(defmethod search ((ldap ldap) filter &key base (scope 'sub)
+		   (deref 'never) (size-limit 0) (time-limit 0)
 		   types-only attributes (paging-size nil))
   "Search the LDAP directory."
   (flet ((search-i (ldap filter base scope deref size-limit time-limit types-only attributes paging-cookie)
            (possibly-reopen-and-rebind ldap)
-           (send-message ldap (msg-search filter base scope deref size-limit 
+           (send-message ldap (msg-search filter base scope deref size-limit
                                           time-limit types-only attributes paging-size paging-cookie))
            (receive-message ldap)
            (parse-ldap-message ldap)))
@@ -1638,7 +1638,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   (flet ((next-search-result-i ()
            (if (results-pending-p ldap)
              (let ((pending-entry (entry-buffer ldap)))
-               (cond 
+               (cond
                 ((not (null pending-entry))
                  (setf (entry-buffer ldap) nil)
                  pending-entry)
@@ -1657,7 +1657,7 @@ LIST-OF-MODS is a list of (type att val) triples."
     `(let ((,ldap ,(second search-form))
  	   (,count 0))
       ,search-form
-      (do ((,var (next-search-result ,ldap) 
+      (do ((,var (next-search-result ,ldap)
  		 (next-search-result ,ldap)))
  	  ((null ,var))
  	(incf ,count)
@@ -1698,7 +1698,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   "Return the sequence of bytes representing a delete message."
   (let ((dn (seq-primitive-string (dn dn-or-entry))))
     (ber-msg +ber-del-tag+ dn)))
-	
+
 (defun msg-moddn (dn-or-entry new-rdn delete-old new-sup)
   "Return the sequence of bytes representing a moddn message."
   (let ((dn  (seq-octet-string (dn dn-or-entry)))
@@ -1716,8 +1716,8 @@ LIST-OF-MODS is a list of (type att val) triples."
 (defun msg-modify (dn-or-entry mod-list)
   "Return the sequence of bytes representing a modify message."
   (let ((dn (seq-octet-string (dn dn-or-entry)))
-	(mods 
-	 (mapcan #'(lambda (x) (seq-sequence 
+	(mods
+	 (mapcan #'(lambda (x) (seq-sequence
 				(nconc
 				 (seq-enumerated (ldap-modify-type (first x)))
 				 (seq-att-and-values (second x) (third x)))))
@@ -1733,7 +1733,11 @@ LIST-OF-MODS is a list of (type att val) triples."
 	(size   (seq-integer size))
 	(time   (seq-integer time))
 	(types  (seq-boolean types))
-	(attrs  (seq-attribute-list attrs))
+        (attrs
+          (seq-attribute-list (case attrs
+                                ((nil) '("1.1")) ; No attributes
+                                ((t)   nil)      ; All attributes
+                                (t     attrs)))) ; those requested
         (controls
          (when (and paging-size
                     (zerop size))
@@ -1746,7 +1750,7 @@ LIST-OF-MODS is a list of (type att val) triples."
                                                         (nconc
                                                          (seq-integer paging-size)
                                                          (seq-octet-string paging-cookie))))))))))
-    (ber-msg +ber-search-tag+ 
+    (ber-msg +ber-search-tag+
 	     (append base scope deref size time types filter attrs controls))))
 
 ;;;;
@@ -1756,7 +1760,7 @@ LIST-OF-MODS is a list of (type att val) triples."
 (defun read-decoder (response)
   "Decode a BER encoded response (minus initial byte & length) from LDAP."
   (let ((appname (ldap-command-sym (read-app-number (pop-byte response)))))
-    (read-length response) ;; skip length 
+    (read-length response) ;; skip length
     (values (read-generic response) appname)))
 
 (defun read-controls (message)
@@ -1816,7 +1820,7 @@ LIST-OF-MODS is a list of (type att val) triples."
   "Read an octet vector from the message."
   (let ((length (read-length message)))
     (with-slots (vec ptr) message
-      (prog1 
+      (prog1
           (subseq vec ptr (+ ptr length))
         (incf ptr length)))))
 
@@ -1833,7 +1837,7 @@ LIST-OF-MODS is a list of (type att val) triples."
 
 (defun read-message-number (response expected-mesg-number)
   "Read message number from the seq, return t or nil."
-  (pop-byte response) ; pop tag byte for 
+  (pop-byte response) ; pop tag byte for
   (let ((value (read-integer response)))
     (or (zerop value) ; 0 is unsolicited notification.
         (= value expected-mesg-number))))


### PR DESCRIPTION
This change implements the attribute selection as suggested by  @rwiker in 
[issue #7](https://github.com/rwiker/trivial-ldap/issues/7).

The `:attributes` parameter of `ldap:search` can take the following forms:
- `nil` -- no attributes will be returned
- `t`  -- all (user) attributes will be returned 
- `(a list of attributes)` -- the requested attributes will be returned

Nota Bene: currently trivial-ldap will always return the attribute used as the RDN for the
entry, even if asked to return no attributes at all.
